### PR TITLE
Feature/home

### DIFF
--- a/flowers-ol/demo_app/fixtures/demoData.json
+++ b/flowers-ol/demo_app/fixtures/demoData.json
@@ -26,7 +26,7 @@
             "description": "Demo task",
             "prompt": "Start demo task",
             "view_name": "questionnaire",
-            "exit_view": "home",
+            "exit_view": "exit_demo_task",
             "info_templates_csv": "Basic information tabs=basic_tab.html",
             "extra_json": {
                 "instruments": [

--- a/flowers-ol/demo_app/fixtures/demoData.json
+++ b/flowers-ol/demo_app/fixtures/demoData.json
@@ -34,5 +34,25 @@
                 ]
             }
         }
-    }
+    },
+    {
+		"model": "survey_app.Question",
+		"fields": {
+			"instrument": "DEMO",
+			"component": "long_term",
+			"group": 1,
+			"handle": "prof-1",
+			"order": 1,
+			"prompt": "Taille de la diagonale de votre écran en cm",
+			"reverse": 0,
+			"min_val": 0,
+			"max_val": 1,
+			"step": 1,
+			"annotations": "none",
+			"widget": "multiple-widget",
+			"type": "float",
+			"help_text": "Taille en cm (ce paramètre peut être retrouvé dans les paramètres d'écran)",
+			"validate": "is_pos_num"
+		}
+	}
 ]

--- a/flowers-ol/demo_app/urls.py
+++ b/flowers-ol/demo_app/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('demo_questionnaire', views.demo_questionnaire, name='demo_questionnaire'),
+    path('exit_demo_task', views.exit_demo_task, name='exit_demo_task'),
 ]

--- a/flowers-ol/demo_app/views.py
+++ b/flowers-ol/demo_app/views.py
@@ -13,3 +13,9 @@ from survey_app.models import Question, Answer
 def demo_questionnaire(request):
     print('Call to `demo_questionnaire` view in demo_app/views.py')
     return redirect(reverse('home'))
+
+
+@login_required
+def exit_demo_task(request):
+    request.session['exit_view_done'] = True
+    return redirect(reverse('end_task'))

--- a/flowers-ol/manager_app/forms.py
+++ b/flowers-ol/manager_app/forms.py
@@ -47,14 +47,13 @@ class SignUpForm(forms.ModelForm):
         # Create ParticipantProfile and register participant's study
         self.instance.set_password(self.cleaned_data['password'])
         self.instance.save()
-
         participant_profile = ParticipantProfile()
         participant_profile.user = self.instance
         participant_profile.study = study
         participant_profile.save()
 
-        super(SignUpForm, self).save(*args, **kwargs)
-
+        user = super(SignUpForm, self).save(*args, **kwargs)
+        return user
 
     def clean(self):
         cleaned_data = super(SignUpForm, self).clean()

--- a/flowers-ol/manager_app/forms.py
+++ b/flowers-ol/manager_app/forms.py
@@ -51,7 +51,8 @@ class SignUpForm(forms.ModelForm):
         participant_profile.user = self.instance
         participant_profile.study = study
         participant_profile.save()
-
+        participant_profile.assign_sessions()
+        
         user = super(SignUpForm, self).save(*args, **kwargs)
         return user
 

--- a/flowers-ol/manager_app/templates/home_page.html
+++ b/flowers-ol/manager_app/templates/home_page.html
@@ -48,9 +48,7 @@
         {% endif %}
         {% if CONTEXT.participant.current_task.prompt %}
             <div class="btn-panel">
-                <a class="btn" href={% url "start_task" %}>
-                </a>
-                    {{CONTEXT.participant.current_task.prompt}}
+                <a class="btn" href={% url "start_task" %}>{{CONTEXT.participant.current_task.prompt}}</a>
             </div>
         {% endif %}
     </div>

--- a/flowers-ol/manager_app/views.py
+++ b/flowers-ol/manager_app/views.py
@@ -88,9 +88,6 @@ def consent_page(request):
 @never_cache
 def home(request):
     participant = request.user.participantprofile
-    if not participant.consent:
-        return redirect(reverse(consent_page))
-
     try:
         participant.set_current_session()
     except AssertionError:

--- a/flowers-ol/manager_app/views.py
+++ b/flowers-ol/manager_app/views.py
@@ -95,13 +95,17 @@ def home(request):
     if not participant.current_session_valid:
         return redirect(reverse(off_session_page))
 
+    if not participant.current_task.prompt:
+        return redirect(reverse(start_task))
+
     if participant.current_session:
          request.session['active_session'] = json.dumps(True)
+
     if 'messages' in request.session:
         for tag, content in request.session['messages'].items():
             print(tag, content)
             django_messages.add_message(request, getattr(django_messages, tag.upper()), content)
-    return render(request, 'home_page.html', { 'CONTEXT': {'participant': participant}})
+    return render(request, 'home_page.html', {'CONTEXT': {'participant': participant}})
 
 
 @login_required

--- a/flowers-ol/manager_app/views.py
+++ b/flowers-ol/manager_app/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth import authenticate, login, logout
 from django.contrib import messages as django_messages
 from django.views.decorators.cache import never_cache
 from django.utils.translation import LANGUAGE_SESSION_KEY
+from django.utils.translation import gettext as _
 
 import json, datetime
 

--- a/flowers-ol/survey_app/forms.py
+++ b/flowers-ol/survey_app/forms.py
@@ -4,6 +4,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Submit, Row, Div, HTML
 from django.core.exceptions import *
 from . import validators
+from django.utils.translation import gettext as _
 
 
 class QuestionnaireForm(forms.Form):

--- a/flowers-ol/survey_app/templates/tasks/JOLD_Questionnaire/question_block.html
+++ b/flowers-ol/survey_app/templates/tasks/JOLD_Questionnaire/question_block.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load i18n %}
 {% load static %}
 {% block title %}JOLD Questionnaire{% endblock %}
 {% block js%}


### PR DESCRIPTION
Correct several bugs related to manager_app / survey_app and demo_app. After merging to develop please consider pulling this new content to app/feature branches.

**Minor bugs fixed (mostly for tests purposes):**
_In manager app:_

- SignUpForm now returns the instance of the created user and assign the sessions of the new participantprofile
- Import gettext in manager_app.view
- Correct the display of the prompt button in home-page.html

_In survey app:_

- Add translation tag in question_block.html and import gettext in survey-app.view

_In demo app:_

- Add a new question to the demo-task
- Create an exit view

**Major proposition:**
It is now possible to omit the field "prompt" in an ExperimentSession: this lead to the start of the task when redirected by the home view (tldr no instruction is displayed). In this case, Info_templates_csv can also be blank. 